### PR TITLE
Allow reading no-comma padded input files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', encoding='utf-8') as handle:
 
 PACKAGE = 'sample_sheet'
 PACKAGE_NAME = 'sample-sheet'
-VERSION = '0.6.0'
+VERSION = '0.7.0'
 
 URL = f'https://github.com/clintval/{PACKAGE_NAME}'
 ARTIFACT = f'https://github.com/clintval/{PACKAGE_NAME}/archive/v{VERSION}.tar.gz'  # noqa

--- a/tests/resources/paired-end-single-index-no-pad.csv
+++ b/tests/resources/paired-end-single-index-no-pad.csv
@@ -1,0 +1,28 @@
+[Header]
+IEM1FileVersion,4
+Investigator Name,jdoe
+Experiment Name,exp001
+Date,11/16/2017
+Workflow,SureSelectXT
+Application,NextSeq FASTQ Only
+Assay,SureSelectXT
+Description,A description of this flow cell
+Chemistry,Default
+
+[Reads]
+151
+151
+
+[Settings]
+CreateFastqForIndexReads,1
+BarcodeMismatches,2
+
+[Data]
+Sample_ID,Sample_Name,index,Description,Library_ID,Read_Structure,Reference_Name,Sample_Project,Target_Set
+1823A,1823A-tissue,GAATCTGA,0.5x treatment,2017-01-20,151T8B151T,mm10,exp001,Intervals-001
+1823B,1823B-tissue,AGCAGGAA,0.5x treatment,2017-01-20,151T8B151T,mm10,exp001,Intervals-001
+1824A,1824A-tissue,GAGCTGAA,1.0x treatment,2017-01-20,151T8B151T,mm10,exp001,Intervals-001
+1825A,1825A-tissue,AAACATCG,10.0x treatment,2017-01-20,151T8B151T,mm10,exp001,Intervals-001
+1826A,1826A-tissue,GAGTTAGC,100.0x treatment,2017-01-20,151T8B151T,mm10,exp001,Intervals-001
+1826B,1823A-tissue,CGAACTTA,0.5x treatment,2017-01-17,151T8B151T,mm10,exp001,Intervals-001
+1829A,1823B-tissue,GATAGACA,0.5x treatment,2017-01-17,151T8B151T,mm10,exp001,Intervals-001

--- a/tests/test_sample_sheet.py
+++ b/tests/test_sample_sheet.py
@@ -523,8 +523,22 @@ class TestSampleSheet(TestCase):
 
         string_handle.seek(0)
 
-        with open(infile, 'r', newline='\n', encoding='utf-8') as file_handle:
-            self.assertMultiLineEqual(string_handle.read(), file_handle.read())
+        with open(infile, 'r', newline='\n', encoding='utf-8') as handle:
+            self.assertMultiLineEqual(string_handle.read(), handle.read())
+
+    def test_no_line_comma_pad_read_and_write_with_padding(self):
+        """Test ``SampleSheet()`` for reading non-comma line padded input"""
+        infile_pad = RESOURCES / 'paired-end-single-index.csv'
+        infile_no_pad = RESOURCES / 'paired-end-single-index-no-pad.csv'
+        sample_sheet = SampleSheet(infile_no_pad)
+
+        string_handle = StringIO(newline=None)
+        sample_sheet.write(string_handle)
+
+        string_handle.seek(0)
+
+        with open(infile_pad, 'r', newline='\n', encoding='utf-8') as handle:
+            self.assertMultiLineEqual(string_handle.read(), handle.read())
 
     def test_write_custom_section(self):
         """Test ``write()`` when a custom section is defined"""


### PR DESCRIPTION
NB: `SampleSheet.write()` will still output Sample Sheets with comma padding.