### PR TITLE
Feature support more cellranger indexes

### DIFF
--- a/sample_sheet/__init__.py
+++ b/sample_sheet/__init__.py
@@ -273,7 +273,7 @@ class Sample(CaseInsensitiveDict):
 
     _valid_index_key_pattern = re.compile(r'index\d?')
     # https://kb.10xgenomics.com/hc/en-us/articles/218168503-What-oligos-are-in-my-sample-index-
-    _valid_index_value_pattern = re.compile(r'^[ACGTN]*$|^SI-[ACGTN]{2}-[A-H]\d+$')
+    _valid_index_value_pattern = re.compile(r'^[ACGTN]*$|^SI-[ACGTNS]{2}-[A-H]\d+$')
 
     def __init__(
         self, data: Optional[Mapping] = None, **kwargs: Mapping

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -58,6 +58,7 @@ class TestSample(TestCase):
         eq_(Sample({'index': 'SI-GA-H1'}).index, 'SI-GA-H1')
         eq_(Sample({'index': 'SI-NA-A8'}).index, 'SI-NA-A8')
         eq_(Sample({'index': 'SI-TT-A1'}).index, 'SI-TT-A1')
+        eq_(Sample({'index': 'SI-TS-A1'}).index, 'SI-TS-A1')
         assert_raises(ValueError, Sample, {'index': 'ACUGTN'})
         assert_raises(ValueError, Sample, {'index2': 'ACUGTN'})
 


### PR DESCRIPTION
10X released [Visium Spatial for FFPE](https://support.10xgenomics.com/spatial-gene-expression-ffpe/sequencing/doc/specifications-sample-index-sets-for-visium-spatial-gene-expression-for-ffpe) which uses the Dual Index Kit TS where indexes are provided to cellranger-mkfastq in the form SI-T**S**-*. This PR expands the regex to accept this index format.