### PR TITLE
path.open properly resolves s3 uri for s3path

### DIFF
--- a/sample_sheet/__init__.py
+++ b/sample_sheet/__init__.py
@@ -418,7 +418,7 @@ class SampleSheet(object):
 
         if self.path is not None:
           if isinstance(self.path, (str, Path)):
-            with open(self.path, 'r') as f:
+            with self.path.open('r') as f:
               self._parse(f)
           else:
             self._parse(self.path)


### PR DESCRIPTION
When using [`s3Path`](https://github.com/liormizr/s3path) this open doesn't properly parse the URI to and S3Path. Using `path.open` ensures the underlying `Path` class is opened correctly.